### PR TITLE
Use os.path.sep instead of `/` for getting the migration and seed names

### DIFF
--- a/lib/migrations.py
+++ b/lib/migrations.py
@@ -18,7 +18,7 @@ class MigrationBase:
             raise MigrationError("Migration file not found")
 
         self.filepath = filepath
-        self.filename = filepath.split("/")[-1]
+        self.filename = filepath.split(os.path.sep)[-1]
 
         filename_parts = self.filename.replace(".sql", "").split("_")
         self.version = filename_parts[0]

--- a/lib/seeds.py
+++ b/lib/seeds.py
@@ -23,7 +23,7 @@ class Seed:
             raise SeedError("seed file not found")
 
         self.filepath = filepath
-        self.filename = filepath.split("/")[-1]
+        self.filename = filepath.split(os.path.sep)[-1]
 
         filename_parts = self.filename.replace(".sql", "").split("_")
         self.version = filename_parts[0]


### PR DESCRIPTION
Fixes #5 

Use os.path.sep to get the file separator for the operating system in use. On unix systems this returns `/`, on DOS systems it returns `\`.